### PR TITLE
Add style for Legendary crypts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 First, run the development server:
 
 ```bash
-npm run dev
-# or
 yarn dev
 ```
 

--- a/src/components/realms/Crypt.tsx
+++ b/src/components/realms/Crypt.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import React from "react";
-import { Environments } from "~/util/cryptsEnvironments";
+import { isLegendary, Environments } from "~/util/cryptsEnvironments";
 import { CryptProps } from "../../types";
 import { shortenAddress } from "~/util/formatters";
 import Image from "next/image";
@@ -51,7 +51,11 @@ export function Crypt(props: CryptProps): ReactElement {
               <h4>Size: {props.crypt.size}x{props.crypt.size}</h4>
             </div>
             <h3></h3>
-            <h1 className={`mt-2 mb-4 ${variantMaps[props.size]?.heading}`}>
+            <h1 className={`mt-2 mb-4 ${variantMaps[props.size]?.heading}
+            ${isLegendary(props.crypt.name) && (
+              `text-transparent background-animate bg-clip-text bg-radial-at-tl from-yellow-100 via-yellow-400 to-yellow-100 shimmer fast`
+            )}
+            `}>
               {props.crypt.name}
             </h1>
             <div

--- a/src/util/cryptsEnvironments.ts
+++ b/src/util/cryptsEnvironments.ts
@@ -68,7 +68,7 @@ export const Environments: Array<Environments> = [
    {
       name: 'Ember\'s Glow',
       colours: {
-         main: '#FF1800',
+         main: '#ff422e',
          door: '#FF1800',
          point: '#B75700'
       },

--- a/src/util/cryptsEnvironments.ts
+++ b/src/util/cryptsEnvironments.ts
@@ -75,3 +75,15 @@ export const Environments: Array<Environments> = [
       id: 5,
    }
 ]
+
+/* isLegenday - Determines if a dungeon has legendary status (nearly 1/1). These are important events in the crypts and caverns universe (perhaps Lootverse?) Could be an important battle, a cataclysmic event, or the meeting of important people.
+
+input: name of a dungeon
+returns: true (legendary) or false (not legendary) */
+export function isLegendary(name: String) {
+   // Legendary names are the only ones that start with an apostrophe (`)
+   if(name.slice(0, 1) == "'") {
+      return(true)
+   } 
+   return(false);
+}


### PR DESCRIPTION
I added a basic style ('gold' text / fast shimmer) to the name of legendary dungeons.

I think this makes them stand out without adding an extra variable down below (like a 'legendary' standalone item next to doors/points):
<img width="569" alt="Screen Shot 2022-02-20 at 9 33 01 AM" src="https://user-images.githubusercontent.com/86170641/154855921-754e7b26-fa56-4759-9171-9cda9173c743.png">

Things I plan to improve:
1. Tweak the animation to make it more interesting (it's fairly boring)
2. Migrate all css to the `cryptsEnvironments` util file
3. Add custom colors to `styles/index.css`
