### PR TITLE
Adjusted colors for crypts environments

### DIFF
--- a/src/components/realms/Crypt.tsx
+++ b/src/components/realms/Crypt.tsx
@@ -43,14 +43,14 @@ export function Crypt(props: CryptProps): ReactElement {
                 👑 {shortenAddress(props.crypt.currentOwner.address)}
               </h3>
             )}
-            <div className="flex flex-col sm:flex-row flex-wrap justify-between my-4 rounded">
+            <div className="flex flex-col flex-wrap justify-between my-4 rounded sm:flex-row">
               <h4>
                 Id: <span className="font-semibold ">{props.crypt.id}</span>
               </h4>
               <h4>
-                Enviroment:{" "}
+                Environment:{" "}
                 <span
-                  className="px-4 py-1 rounded font-semibold "
+                  className="px-4 py-1 font-semibold rounded "
                   style={{
                     backgroundColor: `${colours?.main}`,
                   }}

--- a/src/components/realms/Crypt.tsx
+++ b/src/components/realms/Crypt.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import React from "react";
-import { isLegendary, Environments } from "~/util/cryptsEnvironments";
+import { isLegendary, Environments, legendaryColourClass } from "~/util/cryptsEnvironments";
 import { CryptProps } from "../../types";
 import { shortenAddress } from "~/util/formatters";
 import Image from "next/image";
@@ -69,7 +69,7 @@ export function Crypt(props: CryptProps): ReactElement {
               className={`mt-2 mb-4 ${variantMaps[props.size]?.heading}
             ${
               isLegendary(props.crypt.name) &&
-              `text-transparent background-animate bg-clip-text bg-gradient-to-br from-orange-300 via-yellow-400 to-orange-100 shimmer fast`
+              legendaryColourClass
             }
             `}
             >

--- a/src/components/realms/Crypt.tsx
+++ b/src/components/realms/Crypt.tsx
@@ -14,8 +14,8 @@ export function Crypt(props: CryptProps): ReactElement {
   };
 
   const image = props.crypt.svg;
-
-  const colours = findEnvironment(props.crypt.environment)?.colours;
+  const environment = findEnvironment(props.crypt.environment);
+  // const colours = findEnvironment(props.crypt.environment)?.colours;
 
   return (
     <div className="z-10 w-full h-auto p-1 text-white rounded-xl sm:p-4">
@@ -50,13 +50,9 @@ export function Crypt(props: CryptProps): ReactElement {
               <h4>
                 Environment:{" "}
                 <span
-                  className="px-4 py-1 font-semibold rounded "
-                  style={{
-                    backgroundColor: `${colours?.main}`,
-                    color: `${colours?.text}`
-                  }}
+                  className={`px-4 py-1 font-semibold rounded ${environment?.colourClass.main}`}
                 >
-                  {findEnvironment(props.crypt.environment)?.name}
+                  {environment?.name}
                 </span>
               </h4>
               <h4>
@@ -84,10 +80,9 @@ export function Crypt(props: CryptProps): ReactElement {
               <span>Doors: {props.crypt.numPoints} / 13</span>
               <div className="w-full my-2 bg-gray-200 rounded">
                 <div
-                  className="h-2 bg-yellow-700/60 rounded-xl"
+                  className={`h-2 bg-yellow-700/60 rounded-xl ${environment?.colourClass.door}`}
                   style={{
                     width: `${((props.crypt.numPoints as any) / 13) * 100}%`,
-                    background: `${colours?.door}`,
                   }}
                 ></div>
               </div>
@@ -96,10 +91,9 @@ export function Crypt(props: CryptProps): ReactElement {
               </span>
               <div className="w-full my-2 bg-gray-200 rounded">
                 <div
-                  className="h-2 bg-green-500/60 rounded-xl"
+                  className={`h-2 bg-green-500/60 rounded-xl ${environment?.colourClass.point}`}
                   style={{
                     width: `${((props.crypt.numDoors as any) / 12) * 100}%`,
-                    background: `${colours?.point}`,
                   }}
                 ></div>
               </div>

--- a/src/components/realms/Crypt.tsx
+++ b/src/components/realms/Crypt.tsx
@@ -53,6 +53,7 @@ export function Crypt(props: CryptProps): ReactElement {
                   className="px-4 py-1 font-semibold rounded "
                   style={{
                     backgroundColor: `${colours?.main}`,
+                    color: `${colours?.text}`
                   }}
                 >
                   {findEnvironment(props.crypt.environment)?.name}

--- a/src/components/realms/Crypt.tsx
+++ b/src/components/realms/Crypt.tsx
@@ -15,7 +15,6 @@ export function Crypt(props: CryptProps): ReactElement {
 
   const image = props.crypt.svg;
   const environment = findEnvironment(props.crypt.environment);
-  // const colours = findEnvironment(props.crypt.environment)?.colours;
 
   return (
     <div className="z-10 w-full h-auto p-1 text-white rounded-xl sm:p-4">

--- a/src/components/realms/Crypt.tsx
+++ b/src/components/realms/Crypt.tsx
@@ -69,7 +69,7 @@ export function Crypt(props: CryptProps): ReactElement {
               className={`mt-2 mb-4 ${variantMaps[props.size]?.heading}
             ${
               isLegendary(props.crypt.name) &&
-              `text-transparent background-animate bg-clip-text bg-radial-at-tl from-yellow-100 via-yellow-400 to-yellow-100 shimmer fast`
+              `text-transparent background-animate bg-clip-text bg-gradient-to-br from-orange-300 via-yellow-400 to-orange-100 shimmer fast`
             }
             `}
             >

--- a/src/util/cryptsEnvironments.ts
+++ b/src/util/cryptsEnvironments.ts
@@ -10,11 +10,13 @@ There are six environments:
 */
 
 interface Environments {
-   name: String,
+   name: String,           // Name of the environment (e.g. Ember's Glow)
+   colourClass: String,    // Class styles for environment 'pills' (e.g. white text on black bg)
    colours: {
       main: String,
       door: String,
-      point: String
+      point: String,
+      text: String
    },
    id: Number,
 }
@@ -22,55 +24,67 @@ interface Environments {
 export const Environments: Array<Environments> = [
    {
       name: 'Desert Oasis',
+      colourClass: ``,
       colours: {
          main: '#F3D899',
          door: '#00A29D',
-         point: '#FAAA00'
+         point: '#FAAA00',
+         text: 'black'
       },
       id: 0,
    },
    {
       name: 'Stone Temple',
+      colourClass: ``,
       colours: {
-         main: '#c7a687',
+         main: '#967E67',
          door: '#006669',
-         point: '#3C2A1A'
+         point: '#3C2A1A',
+         text: 'white'
       },
       id: 1,
    },
    {
       name: 'Forest Ruins',
+      colourClass: ``,
       colours: {
-         main: '#A98C00',
+         main: '#2F590E',
          door: '#C55300',
-         point: '#802F1A'
+         point: '#802F1A',
+         text: 'white'
       },
       id: 2,
    },
    {
       name: 'Mountain Deep',
+      colourClass: ``,
       colours: {
-         main: '#cf9479',
+         main: '#744936',
          door: '#FFA800',
-         point: '#802F1A'
+         point: '#802F1A',
+         text: 'white'
       },
       id: 3,
    },
    {
       name: 'Underwater Keep',
+      colourClass: ``,
       colours: {
-         main: '#24c2c7',
+         main: '#006669',
          door: '#F9B569',
-         point: '#967E67'
+         point: '#967E67',
+         text: 'white'
       },
       id: 4,
    },
    {
       name: 'Ember\'s Glow',
+      colourClass: ``,
       colours: {
-         main: '#ff422e',
+         main: '#5D0503',
          door: '#FF1800',
-         point: '#B75700'
+         point: '#B75700',
+         text: 'white'
       },
       id: 5,
    }

--- a/src/util/cryptsEnvironments.ts
+++ b/src/util/cryptsEnvironments.ts
@@ -11,12 +11,10 @@ There are six environments:
 
 interface Environments {
    name: String,           // Name of the environment (e.g. Ember's Glow)
-   colourClass: String,    // Class styles for environment 'pills' (e.g. white text on black bg)
-   colours: {
-      main: String,
+   colourClass: {          // Class styles for environment 'pills' (e.g. white text on black bg)
+      main: String,  
       door: String,
-      point: String,
-      text: String
+      point: String
    },
    id: Number,
 }
@@ -24,67 +22,55 @@ interface Environments {
 export const Environments: Array<Environments> = [
    {
       name: 'Desert Oasis',
-      colourClass: ``,
-      colours: {
-         main: '#F3D899',
-         door: '#00A29D',
-         point: '#FAAA00',
-         text: 'black'
+      colourClass: {
+         main: `bg-desert-main text-black`,  /* Use black text because bg-desert-main is cream so white blends in */
+         door: `bg-desert-door`,
+         point: `bg-desert-point`
       },
       id: 0,
    },
    {
       name: 'Stone Temple',
-      colourClass: ``,
-      colours: {
-         main: '#967E67',
-         door: '#006669',
-         point: '#3C2A1A',
-         text: 'white'
+      colourClass: {
+         main: `bg-temple-main`,
+         door: `bg-temple-door`,
+         point: `bg-temple-point`
       },
       id: 1,
    },
    {
       name: 'Forest Ruins',
-      colourClass: ``,
-      colours: {
-         main: '#2F590E',
-         door: '#C55300',
-         point: '#802F1A',
-         text: 'white'
+      colourClass: {
+         main: `bg-forest-main`,
+         door: `bg-forest-door`,
+         point: `bg-forest-point`
       },
       id: 2,
    },
    {
       name: 'Mountain Deep',
-      colourClass: ``,
-      colours: {
-         main: '#744936',
-         door: '#FFA800',
-         point: '#802F1A',
-         text: 'white'
+      colourClass: {
+         main: `bg-mountain-main`,
+         door: `bg-mountain-door`,
+         point: `bg-mountain-point`
       },
       id: 3,
    },
    {
       name: 'Underwater Keep',
-      colourClass: ``,
-      colours: {
-         main: '#006669',
-         door: '#F9B569',
-         point: '#967E67',
-         text: 'white'
+      colourClass: {
+         main: `bg-underwater-main`,
+         door: `bg-underwater-door`,
+         point: `bg-underwater-point`
       },
       id: 4,
    },
    {
       name: 'Ember\'s Glow',
-      colourClass: ``,
-      colours: {
-         main: '#5D0503',
-         door: '#FF1800',
-         point: '#B75700',
-         text: 'white'
+      colourClass: {
+         main: `bg-ember-main`,
+         door: `bg-ember-door`,
+         point: `bg-ember-point`
       },
       id: 5,
    }
@@ -96,12 +82,8 @@ input: name of a dungeon
 returns: true (legendary) or false (not legendary) */
 export function isLegendary(name: String) {
    // Legendary names are the only ones that start with an apostrophe (`)
-   if(name.slice(0, 1) == "'") {
-      return(true)
-   } 
-   return(false);
+   return(name.slice(0, 1) == "'");
 }
 
 /* legendaryColourClass - Applies css to style legendary map */
-
 export const legendaryColourClass = `text-transparent background-animate bg-clip-text bg-gradient-to-br from-orange-300 via-yellow-400 to-orange-100 shimmer fast`

--- a/src/util/cryptsEnvironments.ts
+++ b/src/util/cryptsEnvironments.ts
@@ -87,3 +87,7 @@ export function isLegendary(name: String) {
    } 
    return(false);
 }
+
+/* legendaryColourClass - Applies css to style legendary map */
+
+export const legendaryColourClass = `text-transparent background-animate bg-clip-text bg-gradient-to-br from-orange-300 via-yellow-400 to-orange-100 shimmer fast`

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,7 +53,38 @@ module.exports = {
         off: {
           100: '#F9F7F1',
           200: '#8D795B',
-        }       
+        },
+        /* Crypts and Caverns color styles */
+        desert: { /* Desert Oasis */
+         main: '#F3D899',
+         door: '#00A29D',
+         point: '#FAAA00'
+        },
+        temple: { /* Stone Temple */
+          main: '#967E67',
+          door: '#006669',
+          point: '#3C2A1A'
+        },
+        forest: { /* Forest Ruins */
+          main: '#2F590E',
+          door: '#C55300',
+          point: '#802F1A'
+        },
+        mountain: { /* Mountain Deep */
+          main: '#cf9479',
+          door: '#FFA800',
+          point: '#802F1A'
+        },
+        underwater: { /* Underwater Keep */
+          main: '#006669',
+          door: '#F9B569',
+          point: '#967E67'
+        },
+        ember: { /* Ember's Glow */
+          main: '#5D0503',
+          door: '#FF1800',
+          point: '#B75700',
+        },
       },
     },
   },


### PR DESCRIPTION
* Reverted colors to use the original crypts and caverns backgrounds (vs modified ones to work with dark bg).
* Changed Desert Oasis text color to black on cream (vs white on cream which was hard to read)
* Fixed typo: Enviroment -> Environmen
<img width="543" alt="Screen Shot 2022-02-20 at 4 57 09 PM" src="https://user-images.githubusercontent.com/86170641/154872913-f3d61f4e-6aeb-48a6-af1d-4d1104e818b1.png">
<img width="548" alt="Screen Shot 2022-02-20 at 4 57 04 PM" src="https://user-images.githubusercontent.com/86170641/154872915-76832561-6898-44f8-a110-90c0ec1e1906.png">
t