### PR TITLE
Bug fixes

### DIFF
--- a/apps/atlas/src/components/cards/RealmCard.tsx
+++ b/apps/atlas/src/components/cards/RealmCard.tsx
@@ -143,7 +143,7 @@ export function RealmCard(props: RealmProps): ReactElement {
       //   component: <RealmHistory />,
       // },
     ],
-    []
+    [props.realm?.id]
   );
   return (
     <div className="z-10 w-full h-auto p-1 text-white rounded-xl">
@@ -156,7 +156,7 @@ export function RealmCard(props: RealmProps): ReactElement {
       ) : (
         <div>
           {props.realm?.wonder && (
-            <div className="text-gray-200 w-full p-4 tracking-veryWide shadow-inner text-2xl text-center uppercase rounded bg-white/10 font-semibold border-4 border-gray-500">
+            <div className="w-full p-4 text-2xl font-semibold text-center text-gray-200 uppercase border-4 border-gray-500 rounded shadow-inner tracking-veryWide bg-white/10">
               {props.realm?.wonder}
             </div>
           )}

--- a/apps/atlas/src/components/panels/CryptsPanel.tsx
+++ b/apps/atlas/src/components/panels/CryptsPanel.tsx
@@ -14,7 +14,8 @@ import type { Crypt } from '@/types/index';
 import { BasePanel } from './BasePanel';
 
 export const CryptsPanel = () => {
-  const { togglePanelType, selectedPanel, openDetails } = useUIContext();
+  const { togglePanelType, selectedPanel, openDetails, isDisplayLarge } =
+    useUIContext();
   const { account } = useWalletContext();
   const { state, actions } = useCryptContext();
 
@@ -78,7 +79,7 @@ export const CryptsPanel = () => {
   });
 
   useEffect(() => {
-    if (page === 1 && (data?.dungeons?.length ?? 0) > 0) {
+    if (isDisplayLarge && page === 1 && (data?.dungeons?.length ?? 0) > 0) {
       openDetails('crypt', data?.dungeons[0].id as string);
     }
   }, [data, page]);

--- a/apps/atlas/src/components/panels/GaPanel.tsx
+++ b/apps/atlas/src/components/panels/GaPanel.tsx
@@ -14,7 +14,8 @@ import type { GAdventurer } from '@/types/index';
 import { BasePanel } from './BasePanel';
 
 export const GaPanel = () => {
-  const { togglePanelType, openDetails, selectedPanel } = useUIContext();
+  const { isDisplayLarge, togglePanelType, openDetails, selectedPanel } =
+    useUIContext();
   const { account } = useWalletContext();
   const { state, actions } = useGaContext();
 
@@ -75,7 +76,7 @@ export const GaPanel = () => {
   });
 
   useEffect(() => {
-    if (page === 1 && (data?.gadventurers?.length ?? 0) > 0) {
+    if (isDisplayLarge && page === 1 && (data?.gadventurers?.length ?? 0) > 0) {
       openDetails('ga', data?.gadventurers[0].id as string);
     }
   }, [data, page]);

--- a/apps/atlas/src/components/panels/LootPanel.tsx
+++ b/apps/atlas/src/components/panels/LootPanel.tsx
@@ -14,7 +14,8 @@ import type { Loot } from '@/types/index';
 import { BasePanel } from './BasePanel';
 
 export const LootPanel = () => {
-  const { togglePanelType, selectedPanel, openDetails } = useUIContext();
+  const { isDisplayLarge, togglePanelType, selectedPanel, openDetails } =
+    useUIContext();
   const { account } = useWalletContext();
   const { state, actions } = useLootContext();
 
@@ -65,7 +66,7 @@ export const LootPanel = () => {
   });
 
   useEffect(() => {
-    if (page === 1 && (data?.bags?.length ?? 0) > 0) {
+    if (isDisplayLarge && page === 1 && (data?.bags?.length ?? 0) > 0) {
       openDetails('loot', data?.bags[0].id as string);
     }
   }, [data, page]);

--- a/apps/atlas/src/components/panels/RealmsPanel.tsx
+++ b/apps/atlas/src/components/panels/RealmsPanel.tsx
@@ -13,7 +13,8 @@ import Button from '@/shared/Button';
 import { BasePanel } from './BasePanel';
 
 export const RealmsPanel = () => {
-  const { togglePanelType, selectedPanel, openDetails } = useUIContext();
+  const { isDisplayLarge, togglePanelType, selectedPanel, openDetails } =
+    useUIContext();
   const { account } = useWalletContext();
   const { state, actions } = useRealmContext();
 
@@ -98,7 +99,7 @@ export const RealmsPanel = () => {
   });
 
   useEffect(() => {
-    if (page === 1 && (data?.getRealms?.length ?? 0) > 0) {
+    if (isDisplayLarge && page === 1 && (data?.getRealms?.length ?? 0) > 0) {
       openDetails('realm', data?.getRealms[0].realmId + '');
     }
   }, [data, page]);

--- a/apps/atlas/src/hooks/useUIContext.tsx
+++ b/apps/atlas/src/hooks/useUIContext.tsx
@@ -64,6 +64,7 @@ interface UI {
   toggleMainMenu: () => void;
   togglePanelType: (panelType: PanelType) => void;
   selectedPanel: PanelType;
+  isDisplayLarge: boolean;
 }
 
 const UIContext = createContext<UI>(null!);
@@ -151,10 +152,13 @@ function useUI(): UI {
     query ? assetFilterByType(query.assetType as AssetType) : AssetFilters[0]
   );
 
+  const isDisplayLarge =
+    typeof window !== 'undefined' && window.innerWidth >= 768;
+
   const [artBackground, setArtBackground] = useState<BackgroundOptions>();
   const [mainMenu, setMainMenu] = useState(
     // default closed on small screens
-    typeof window !== 'undefined' && window.innerWidth >= 768
+    isDisplayLarge
   );
 
   const [selectedMenuType, setMenuType] = useState<MenuType>(
@@ -212,12 +216,10 @@ function useUI(): UI {
   const togglePanelType = (panelType: PanelType) => {
     setMainMenu(false);
     if (selectedPanel === panelType) {
-      setShowDetails(false);
       setPanelType(undefined);
       setMenuType(undefined);
       setArtBackground(undefined);
     } else {
-      setShowDetails(true);
       setPanelType(panelType);
       if (panelType === 'crypt') {
         setArtBackground('crypt');
@@ -284,6 +286,7 @@ function useUI(): UI {
     toggleMainMenu,
     togglePanelType,
     selectedPanel,
+    isDisplayLarge,
   };
 }
 


### PR DESCRIPTION
- if you've loaded the Realm before, resources and traits don't update from the previous Realm once you select 'details
- Side panel auto opening on mobile when a filter is selected. It shouldn't open until a user clicks a realm