### PR TITLE
Feat/filter slider range

### DIFF
--- a/apps/atlas/package.json
+++ b/apps/atlas/package.json
@@ -147,6 +147,7 @@
     "@playwright/test": "1.22.2",
     "@popperjs/core": "2.11.5",
     "@quentin-sommer/react-useragent": "3.1.1",
+    "@radix-ui/react-slider": "0.1.4",
     "@react-spring/three": "9.4.5",
     "@react-spring/types": "^9.4.5",
     "@react-spring/web": "^9.4.5",

--- a/apps/atlas/src/components/filters/BagRatingFilter.tsx
+++ b/apps/atlas/src/components/filters/BagRatingFilter.tsx
@@ -2,15 +2,14 @@ import { Button } from '@bibliotheca-dao/ui-lib';
 import { Popover } from '@headlessui/react';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
+import { LootMax } from '@/constants/index';
 import { useOnClickOutsideElement } from '@/hooks/useOnClickOutsideElement';
+import type { MinMaxRange } from '@/types/index';
 import { RangeSliderFilter } from './RangeSliderFilter';
 
-const GreatnessMax = 160;
-const RatingMax = 720;
-
 type BagRating = {
-  bagRating: number;
-  bagGreatness: number;
+  bagRating: MinMaxRange;
+  bagGreatness: MinMaxRange;
 };
 
 type BagRatingFilterProps = {
@@ -26,15 +25,27 @@ export function BagRatingFilter(props: BagRatingFilterProps) {
     setIsOpen(false);
   });
 
-  const onGreatnessFilterChange = (value: number) => {
-    const updatedRating = { ...props.rating, bagGreatness: value };
+  const onGreatnessFilterChange = (value: number[]) => {
+    const updatedRating = {
+      ...props.rating,
+      bagGreatness: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedRating);
   };
 
-  const onRatingFilterChange = (value: number) => {
-    const updatedRating = { ...props.rating, bagRating: value };
+  const onRatingFilterChange = (value: number[]) => {
+    const updatedRating = {
+      ...props.rating,
+      bagRating: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedRating);
   };
+
+  const hasSelectedFilters =
+    props.rating.bagRating.min > 0 ||
+    props.rating.bagRating.max < LootMax.Rating ||
+    props.rating.bagGreatness.min > 0 ||
+    props.rating.bagGreatness.max < LootMax.Greatness;
 
   return (
     <Popover className="relative">
@@ -42,11 +53,7 @@ export function BagRatingFilter(props: BagRatingFilterProps) {
         <Button
           variant="primary"
           size="sm"
-          className={clsx(
-            props.rating.bagGreatness > 0 || props.rating.bagRating > 0
-              ? 'bg-black'
-              : ''
-          )}
+          className={clsx(hasSelectedFilters ? 'bg-black' : '')}
           onClick={() => {
             setIsOpen(!isOpen);
           }}
@@ -64,15 +71,23 @@ export function BagRatingFilter(props: BagRatingFilterProps) {
               <RangeSliderFilter
                 name="Greatness"
                 min={0}
-                max={GreatnessMax}
-                defaultValue={props.rating.bagGreatness}
+                max={LootMax.Greatness}
+                defaultValues={[0, LootMax.Greatness]}
+                values={[
+                  props.rating.bagGreatness.min,
+                  props.rating.bagGreatness.max,
+                ]}
                 onChange={onGreatnessFilterChange}
               />
               <RangeSliderFilter
                 name="Rating"
                 min={0}
-                max={RatingMax}
-                defaultValue={props.rating.bagRating}
+                max={LootMax.Rating}
+                defaultValues={[0, LootMax.Rating]}
+                values={[
+                  props.rating.bagRating.min,
+                  props.rating.bagRating.max,
+                ]}
                 onChange={onRatingFilterChange}
               />
             </div>

--- a/apps/atlas/src/components/filters/CryptStatsFilter.tsx
+++ b/apps/atlas/src/components/filters/CryptStatsFilter.tsx
@@ -2,17 +2,15 @@ import { Button } from '@bibliotheca-dao/ui-lib';
 import { Popover } from '@headlessui/react';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
+import { CryptsMax } from '@/constants/index';
 import { useOnClickOutsideElement } from '@/hooks/useOnClickOutsideElement';
+import type { MinMaxRange } from '@/types/index';
 import { RangeSliderFilter } from './RangeSliderFilter';
 
-const SizeMax = 24;
-const NumDoorsMax = 12;
-const NumPointsMax = 13;
-
 type Stats = {
-  size: number;
-  numDoors: number;
-  numPoints: number;
+  size: MinMaxRange;
+  numDoors: MinMaxRange;
+  numPoints: MinMaxRange;
 };
 
 type CryptStatsFilterProps = {
@@ -28,25 +26,37 @@ export function CryptStatsFilter(props: CryptStatsFilterProps) {
     setIsOpen(false);
   });
 
-  const onSizeFilterChange = (value: number) => {
-    const updatedStats = { ...props.stats, size: value };
+  const onSizeFilterChange = (value: number[]) => {
+    const updatedStats = {
+      ...props.stats,
+      size: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedStats);
   };
 
-  const onNumDoorsFilterChange = (value: number) => {
-    const updatedStats = { ...props.stats, numDoors: value };
+  const onNumDoorsFilterChange = (value: number[]) => {
+    const updatedStats = {
+      ...props.stats,
+      numDoors: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedStats);
   };
 
-  const onNumPointsFilterChange = (value: number) => {
-    const updatedStats = { ...props.stats, numPoints: value };
+  const onNumPointsFilterChange = (value: number[]) => {
+    const updatedStats = {
+      ...props.stats,
+      numPoints: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedStats);
   };
 
   const hasSelectedFilters =
-    props.stats.numDoors > 0 ||
-    props.stats.numPoints > 0 ||
-    props.stats.size > 0;
+    props.stats.numDoors.min > 0 ||
+    props.stats.numDoors.max < CryptsMax.NumDoors ||
+    props.stats.numPoints.min > 0 ||
+    props.stats.numPoints.max < CryptsMax.NumPoints ||
+    props.stats.size.min > 0 ||
+    props.stats.size.max < CryptsMax.Size;
 
   return (
     <Popover className="relative">
@@ -72,22 +82,25 @@ export function CryptStatsFilter(props: CryptStatsFilterProps) {
               <RangeSliderFilter
                 name="Size"
                 min={0}
-                max={SizeMax}
-                defaultValue={props.stats.size}
+                max={CryptsMax.Size}
+                defaultValues={[0, CryptsMax.Size]}
+                values={[props.stats.size.min, props.stats.size.max]}
                 onChange={onSizeFilterChange}
               />
               <RangeSliderFilter
                 name="Doors"
                 min={0}
-                max={NumPointsMax}
-                defaultValue={props.stats.numPoints}
+                max={CryptsMax.NumDoors}
+                defaultValues={[0, CryptsMax.NumDoors]}
+                values={[props.stats.numDoors.min, props.stats.numDoors.max]}
                 onChange={onNumDoorsFilterChange}
               />
               <RangeSliderFilter
                 name="Points"
                 min={0}
-                max={NumDoorsMax}
-                defaultValue={props.stats.numDoors}
+                max={CryptsMax.NumPoints}
+                defaultValues={[0, CryptsMax.NumPoints]}
+                values={[props.stats.numPoints.min, props.stats.numPoints.max]}
                 onChange={onNumPointsFilterChange}
               />
             </div>

--- a/apps/atlas/src/components/filters/RangeSliderFilter.tsx
+++ b/apps/atlas/src/components/filters/RangeSliderFilter.tsx
@@ -1,191 +1,49 @@
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
-import { useWindowSize } from '@/hooks/useWindowSize';
-
-interface Rect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
+import * as SliderPrimitive from '@radix-ui/react-slider';
+import React from 'react';
 interface RangeSliderFilterProps {
   name: string;
   min: number;
   max: number;
-  defaultValue: number;
-  onChange(value: number): void;
+  values?: number[];
+  defaultValues: number[];
+  onChange(values: number[]): void;
+  stepSize?: number;
+  className?: string;
 }
 
-export function RangeSliderFilter(props: RangeSliderFilterProps) {
-  // Slider state
-  const [state, setState] = useState({
-    isDragging: false,
-    animate: true,
-    origin: { x: 0, y: 0 },
-    translation: { x: 0, y: 0 },
-    selectedValue: props.defaultValue ?? props.min,
-  });
+export const RangeSliderFilter = React.forwardRef<any, RangeSliderFilterProps>(
+  (props, forwardedRef) => {
+    const value = props.values || props.defaultValues;
 
-  // Check for window resizes
-  const windowSize = useWindowSize();
+    const valueDisplay = `${value[0]}-${value[1]}`;
 
-  // Utilities
-  const getSelectedValue = (x: number) => {
-    let idx = boundaries.findIndex((boundary) => boundary > x);
-    if (idx === -1) idx = range;
-    return props.min + idx;
-  };
-
-  const getSliderState = (clientX: number, animate: boolean) => {
-    const translation = {
-      x:
-        clientX < boundingRect.x
-          ? 0
-          : Math.min(clientX - boundingRect.x, boundingRect.width - sliderSize),
-      y: 0,
-    };
-
-    return {
-      ...state,
-      translation,
-      animate,
-      selectedValue: getSelectedValue(translation.x),
-    };
-  };
-
-  // Calculate boundaries
-  const range = props.max - props.min;
-  const sliderSize = 10;
-  const [boundingRect, setBoundingRect] = useState<Rect>({
-    width: 0,
-    height: 0,
-    x: 0,
-    y: 0,
-  });
-
-  const containerRef = useCallback(
-    (node) => {
-      if (node !== null) {
-        const { width, height, x, y } = node.getBoundingClientRect();
-        setBoundingRect({ width, height, x, y });
-      }
-    },
-    [windowSize]
-  );
-
-  const [boundaries, setBoundaries] = useState<number[]>([]);
-  useMemo(() => {
-    const boundaries: any[] = [];
-    const step = (boundingRect.width - sliderSize) / range;
-    for (let i = step / 2; i < boundingRect.width - sliderSize; i = i + step) {
-      boundaries.push(i);
-    }
-
-    setBoundaries(boundaries);
-
-    // Initialize slider if defaultValue is given
-    if (props.defaultValue) {
-      const updatedState = getSliderState(
-        step * props.defaultValue + boundingRect.x,
-        false
-      );
-      setState({
-        ...updatedState,
-        isDragging: false,
-        selectedValue: props.defaultValue,
-      });
-    }
-  }, [boundingRect, props.defaultValue]);
-
-  // Handle Mouse Events
-  const handleMouseDown = useCallback(({ clientX, clientY }) => {
-    setState((state) => ({
-      ...state,
-      isDragging: true,
-      animate: false,
-      origin: { x: clientX, y: clientY },
-    }));
-  }, []);
-
-  const handleMouseUp = useCallback(() => {
-    setState((state) => ({
-      ...state,
-      isDragging: false,
-    }));
-  }, []);
-
-  const handleMouseMove = useCallback(
-    ({ clientX }) => {
-      const updatedState = getSliderState(clientX, false);
-      setState(updatedState);
-
-      // Notify drag state here, if needed
-    },
-    [state.origin, boundaries]
-  );
-
-  const handleMouseClick = ({ clientX }: { clientX: number }) => {
-    const updatedState = getSliderState(clientX, true);
-    setState(updatedState);
-    props.onChange(getSelectedValue(updatedState.translation.x));
-  };
-
-  useEffect(() => {
-    if (state.isDragging) {
-      window.addEventListener('mousemove', handleMouseMove);
-      window.addEventListener('mouseup', handleMouseUp);
-    } else {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseup', handleMouseUp);
-      props.onChange(state.selectedValue);
-    }
-  }, [state.isDragging]);
-
-  // Update slider style on transition changes
-  const styles = useMemo(
-    () => ({
-      cursor: state.isDragging ? '-webkit-grabbing' : '-webkit-grab',
-      transform: `translate(${state.translation.x}px)`,
-      transition:
-        !state.animate || state.isDragging ? 'none' : 'transform 500ms',
-      zIndex: state.isDragging ? 2 : 1,
-      borderRadius: sliderSize,
-      width: sliderSize,
-      height: sliderSize,
-    }),
-    [state.isDragging, state.translation]
-  );
-
-  return (
-    <div className="relative w-full my-2">
-      <div className="text-sm tracking-widest text-center uppercase">
-        {props.name}
-      </div>
-      <div
-        className="relative w-full"
-        style={{ height: styles.height }}
-        ref={containerRef}
-      >
-        <div
-          className="bg-[#bd9e3a] inline-block absolute select-none"
-          style={styles as any}
-          onMouseDown={handleMouseDown}
-          role="button"
-          aria-hidden="true"
-        ></div>
-        <div
-          role="button"
-          className="w-full h-full cursor-pointer"
-          onClick={handleMouseClick}
-          aria-hidden="true"
-        >
-          <div className="absolute w-full bg-[#bd9e3a] h-[2px] top-1/2"></div>
+    return (
+      <div className={props.className || 'mb-3'}>
+        <div className="flex justify-between w-full">
+          <span>{props.name}</span> <span>{valueDisplay}</span>
         </div>
+        <SliderPrimitive.Slider
+          className="relative flex items-center w-full h-4 select-none"
+          step={props.stepSize || 1}
+          value={value}
+          min={props.min}
+          max={props.max}
+          onValueChange={(vals) => props.onChange(vals)}
+          ref={forwardedRef}
+        >
+          <SliderPrimitive.Track className="relative flex-1 h-1 bg-white rounded-full cursor-pointer">
+            <SliderPrimitive.Range className="absolute h-full bg-yellow-700 rounded-full" />
+          </SliderPrimitive.Track>
+          {value.map((_, i) => (
+            <SliderPrimitive.Thumb
+              className="block w-4 h-4 bg-white rounded-full shadow-md cursor-move hover:bg-gray-300 shadow-black"
+              key={i}
+            />
+          ))}
+        </SliderPrimitive.Slider>
       </div>
-      <div className="flex justify-between w-full uppercase text-[16px] top-3 select-none mt-2">
-        <span> {state.selectedValue}</span>
-        <span> {props.max}</span>
-      </div>
-    </div>
-  );
-}
+    );
+  }
+);
+
+RangeSliderFilter.displayName = 'RangeSliderFilter';

--- a/apps/atlas/src/components/filters/RealmsRarityFilter.tsx
+++ b/apps/atlas/src/components/filters/RealmsRarityFilter.tsx
@@ -2,15 +2,14 @@ import { Button } from '@bibliotheca-dao/ui-lib';
 import { Popover } from '@headlessui/react';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
+import { RealmsMax } from '@/constants/index';
 import { useOnClickOutsideElement } from '@/hooks/useOnClickOutsideElement';
+import type { MinMaxRange } from '@/types/index';
 import { RangeSliderFilter } from './RangeSliderFilter';
 
-const ScoreMax = 400;
-const RankMax = 7992;
-
 type RealmsRarity = {
-  rarityScore: number;
-  rarityRank: number;
+  score: MinMaxRange;
+  rank: MinMaxRange;
 };
 
 type RealmsRarityFilterProps = {
@@ -21,23 +20,34 @@ type RealmsRarityFilterProps = {
 export function RealmsRarityFilter(props: RealmsRarityFilterProps) {
   const [isOpen, setIsOpen] = useState(false);
 
+  const { rarity } = props;
+
   const ref = useRef(null);
   useOnClickOutsideElement(ref, () => {
     setIsOpen(false);
   });
 
-  const onScoreFilterChange = (value: number) => {
-    const updatedRarity = { ...props.rarity, rarityScore: value };
+  const onScoreFilterChange = (value: number[]) => {
+    const updatedRarity = {
+      ...props.rarity,
+      score: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedRarity);
   };
 
-  const onRankFilterChange = (value: number) => {
-    const updatedRarity = { ...props.rarity, rarityRank: value };
+  const onRankFilterChange = (value: number[]) => {
+    const updatedRarity = {
+      ...props.rarity,
+      rank: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedRarity);
   };
 
   const hasSelectedFilters =
-    props.rarity.rarityRank > 0 || props.rarity.rarityScore > 0;
+    props.rarity.rank.min > 0 ||
+    props.rarity.rank.max < RealmsMax.Rank ||
+    props.rarity.score.min > 0 ||
+    props.rarity.score.max < RealmsMax.Score;
 
   return (
     <Popover className="relative">
@@ -58,20 +68,24 @@ export function RealmsRarityFilter(props: RealmsRarityFilterProps) {
             className="absolute z-10 mt-2 ml-2 sm:translate-x-0 sm:left-0 md:-translate-x-1/2 md:left-1/2"
             static
           >
-            <div className="flex flex-col gap-6 px-8 py-4 pb-10 font-medium text-white bg-black rounded shadow-sm w-60">
+            <div className="flex flex-col px-8 py-4 pb-10 font-medium text-white bg-black rounded shadow-sm w-60">
               <h4 className="text-center">Rarity</h4>
               <RangeSliderFilter
                 name="Score"
                 min={0}
-                max={ScoreMax}
-                defaultValue={props.rarity.rarityScore}
+                max={RealmsMax.Score}
+                stepSize={50}
+                values={[rarity.score.min, rarity.score.max]}
+                defaultValues={[0, RealmsMax.Score]}
                 onChange={onScoreFilterChange}
               />
               <RangeSliderFilter
                 name="Rank"
                 min={0}
-                max={RankMax}
-                defaultValue={props.rarity.rarityRank}
+                max={RealmsMax.Rank}
+                stepSize={50}
+                values={[rarity.rank.min, rarity.rank.max]}
+                defaultValues={[0, RealmsMax.Rank]}
                 onChange={onRankFilterChange}
               />
             </div>

--- a/apps/atlas/src/components/filters/TraitsFilter.tsx
+++ b/apps/atlas/src/components/filters/TraitsFilter.tsx
@@ -2,20 +2,17 @@ import { Button } from '@bibliotheca-dao/ui-lib';
 import { Popover } from '@headlessui/react';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
+import { RealmsMax } from '@/constants/index';
 import { RealmTraitType } from '@/generated/graphql';
 import { useOnClickOutsideElement } from '@/hooks/useOnClickOutsideElement';
+import type { MinMaxRange } from '@/types/index';
 import { RangeSliderFilter } from './RangeSliderFilter';
 
-const RegionMax = 7;
-const CityMax = 21;
-const HarbourMax = 35;
-const RiverMax = 60;
-
 type Traits = {
-  [RealmTraitType.Region]: number;
-  [RealmTraitType.City]: number;
-  [RealmTraitType.Harbor]: number;
-  [RealmTraitType.River]: number;
+  [RealmTraitType.Region]: MinMaxRange;
+  [RealmTraitType.City]: MinMaxRange;
+  [RealmTraitType.Harbor]: MinMaxRange;
+  [RealmTraitType.River]: MinMaxRange;
 };
 
 type TraitsFilterProps = {
@@ -31,31 +28,47 @@ export function TraitsFilter(props: TraitsFilterProps) {
     setIsOpen(false);
   });
 
-  const onRegionFilterChange = (value: number) => {
-    const updatedTraits = { ...props.traits, [RealmTraitType.Region]: value };
+  const onRegionFilterChange = (value: number[]) => {
+    const updatedTraits = {
+      ...props.traits,
+      [RealmTraitType.Region]: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedTraits);
   };
 
-  const onCityFilterChange = (value: number) => {
-    const updatedTraits = { ...props.traits, [RealmTraitType.City]: value };
+  const onCityFilterChange = (value: number[]) => {
+    const updatedTraits = {
+      ...props.traits,
+      [RealmTraitType.City]: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedTraits);
   };
 
-  const onHarbourFilterChange = (value: number) => {
-    const updatedTraits = { ...props.traits, [RealmTraitType.Harbor]: value };
+  const onHarbourFilterChange = (value: number[]) => {
+    const updatedTraits = {
+      ...props.traits,
+      [RealmTraitType.Harbor]: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedTraits);
   };
 
-  const onRiverFilterChange = (value: number) => {
-    const updatedTraits = { ...props.traits, [RealmTraitType.River]: value };
+  const onRiverFilterChange = (value: number[]) => {
+    const updatedTraits = {
+      ...props.traits,
+      [RealmTraitType.River]: { min: value[0], max: value[1] },
+    };
     props.onChange(updatedTraits);
   };
 
   const hasSelectedFilters =
-    props.traits.River > 0 ||
-    props.traits.City > 0 ||
-    props.traits.Harbor > 0 ||
-    props.traits.Region > 0;
+    props.traits.River.min > 0 ||
+    props.traits.River.max < RealmsMax.River ||
+    props.traits.City.min > 0 ||
+    props.traits.City.max < RealmsMax.City ||
+    props.traits.Harbor.min > 0 ||
+    props.traits.Harbor.max < RealmsMax.Harbour ||
+    props.traits.Region.min > 0 ||
+    props.traits.Region.max < RealmsMax.Region;
 
   return (
     <Popover className="relative">
@@ -78,29 +91,45 @@ export function TraitsFilter(props: TraitsFilterProps) {
               <RangeSliderFilter
                 name="Regions"
                 min={0}
-                max={RegionMax}
-                defaultValue={props.traits[RealmTraitType.Region]}
+                max={RealmsMax.Region}
+                values={[
+                  props.traits[RealmTraitType.Region].min,
+                  props.traits[RealmTraitType.Region].max,
+                ]}
+                defaultValues={[0, RealmsMax.Region]}
                 onChange={onRegionFilterChange}
               />
               <RangeSliderFilter
                 name="Cities"
                 min={0}
-                max={CityMax}
-                defaultValue={props.traits[RealmTraitType.City]}
+                max={RealmsMax.City}
+                values={[
+                  props.traits[RealmTraitType.City].min,
+                  props.traits[RealmTraitType.City].max,
+                ]}
+                defaultValues={[0, RealmsMax.City]}
                 onChange={onCityFilterChange}
               />
               <RangeSliderFilter
                 name="Harbours"
                 min={0}
-                max={HarbourMax}
-                defaultValue={props.traits[RealmTraitType.Harbor]}
+                max={RealmsMax.Harbour}
+                values={[
+                  props.traits[RealmTraitType.Harbor].min,
+                  props.traits[RealmTraitType.Harbor].max,
+                ]}
+                defaultValues={[0, RealmsMax.Harbour]}
                 onChange={onHarbourFilterChange}
               />
               <RangeSliderFilter
                 name="Rivers"
                 min={0}
-                max={RiverMax}
-                defaultValue={props.traits[RealmTraitType.River]}
+                max={RealmsMax.River}
+                values={[
+                  props.traits[RealmTraitType.River].min,
+                  props.traits[RealmTraitType.River].max,
+                ]}
+                defaultValues={[0, RealmsMax.River]}
                 onChange={onRiverFilterChange}
               />
             </div>

--- a/apps/atlas/src/components/panels/CryptsPanel.tsx
+++ b/apps/atlas/src/components/panels/CryptsPanel.tsx
@@ -58,9 +58,13 @@ export const CryptsPanel = () => {
       where.name_starts_with = "'";
     }
 
-    where.numDoors_gte = state.statsFilter.numDoors;
-    where.numPoints_gte = state.statsFilter.numPoints;
-    where.size_gte = state.statsFilter.size;
+    where.numDoors_gte = state.statsFilter.numDoors.min;
+    where.numDoors_lte = state.statsFilter.numDoors.max;
+    where.numPoints_gte = state.statsFilter.numPoints.min;
+    where.numPoints_lte = state.statsFilter.numPoints.max;
+    where.size_gte = state.statsFilter.size.min;
+    where.size_lte = state.statsFilter.size.max;
+
     if (state.environmentsFilter.length > 0) {
       where.environment_in = [...state.environmentsFilter];
     }

--- a/apps/atlas/src/components/panels/GaPanel.tsx
+++ b/apps/atlas/src/components/panels/GaPanel.tsx
@@ -51,8 +51,10 @@ export const GaPanel = () => {
     if (state.selectedTab === 0) {
       where.currentOwner = account?.toLowerCase();
     }
-    where.bagGreatness_gt = state.ratingFilter.bagGreatness;
-    where.bagRating_gt = state.ratingFilter.bagRating;
+    where.bagGreatness_gte = state.ratingFilter.bagGreatness.min;
+    where.bagGreatness_lte = state.ratingFilter.bagGreatness.max;
+    where.bagRating_gte = state.ratingFilter.bagRating.min;
+    where.bagRating_lte = state.ratingFilter.bagRating.max;
 
     if (state.selectedOrders.length > 0) {
       where.order_in = [

--- a/apps/atlas/src/components/panels/LootPanel.tsx
+++ b/apps/atlas/src/components/panels/LootPanel.tsx
@@ -50,8 +50,11 @@ export const LootPanel = () => {
     if (state.selectedTab === 0) {
       where.currentOwner = account?.toLowerCase();
     }
-    where.bagGreatness_gt = state.ratingFilter.bagGreatness;
-    where.bagRating_gt = state.ratingFilter.bagRating;
+    where.bagGreatness_gte = state.ratingFilter.bagGreatness.min;
+    where.bagGreatness_lte = state.ratingFilter.bagGreatness.max;
+    where.bagRating_gte = state.ratingFilter.bagRating.min;
+    where.bagRating_lte = state.ratingFilter.bagRating.max;
+
     return {
       first: limit,
       skip: limit * (page - 1),

--- a/apps/atlas/src/components/panels/RealmsPanel.tsx
+++ b/apps/atlas/src/components/panels/RealmsPanel.tsx
@@ -39,8 +39,8 @@ export const RealmsPanel = () => {
     state.selectedOrders,
     state.searchIdFilter,
     state.hasWonderFilter,
-    state.rarityFilter.rarityRank,
-    state.rarityFilter.rarityScore,
+    state.rarityFilter.rank,
+    state.rarityFilter.score,
     state.traitsFilter.City,
     state.traitsFilter.Harbor,
     state.traitsFilter.Region,
@@ -58,12 +58,15 @@ export const RealmsPanel = () => {
 
     const traitsFilters = Object.keys(state.traitsFilter)
       // Filter 0 entries
-      .filter((key: string) => (state.traitsFilter as any)[key])
+      .filter((key: string) => state.traitsFilter[key])
       .map((key: string) => ({
         traits: {
           some: {
             type: { equals: key as RealmTraitType },
-            qty: { gte: (state.traitsFilter as any)[key] },
+            qty: {
+              gte: state.traitsFilter[key].min,
+              lte: state.traitsFilter[key].max,
+            },
           },
         },
       }));
@@ -96,8 +99,14 @@ export const RealmsPanel = () => {
       };
     }
 
-    filter.rarityRank = { gte: state.rarityFilter.rarityRank };
-    filter.rarityScore = { gte: state.rarityFilter.rarityScore };
+    filter.rarityRank = {
+      gte: state.rarityFilter.rank.min,
+      lte: state.rarityFilter.rank.max,
+    };
+    filter.rarityScore = {
+      gte: state.rarityFilter.score.min,
+      lte: state.rarityFilter.score.max,
+    };
     filter.orderType =
       state.selectedOrders.length > 0
         ? { in: [...state.selectedOrders] }

--- a/apps/atlas/src/constants/index.ts
+++ b/apps/atlas/src/constants/index.ts
@@ -29,3 +29,8 @@ export enum LootMax {
   Greatness = 160,
   Rating = 720,
 }
+export enum CryptsMax {
+  Size = 24,
+  NumDoors = 12,
+  NumPoints = 13,
+}

--- a/apps/atlas/src/constants/index.ts
+++ b/apps/atlas/src/constants/index.ts
@@ -15,3 +15,13 @@ export enum ElementToken {
 
 export const DAY_CYCLE = 1800;
 export const RAIDABLE_PERCENTAGE = 25;
+
+export enum RealmsMax {
+  Score = 400,
+  Rank = 7992,
+
+  Region = 7,
+  City = 21,
+  Harbour = 35,
+  River = 60,
+}

--- a/apps/atlas/src/constants/index.ts
+++ b/apps/atlas/src/constants/index.ts
@@ -25,3 +25,7 @@ export enum RealmsMax {
   Harbour = 35,
   River = 60,
 }
+export enum LootMax {
+  Greatness = 160,
+  Rating = 720,
+}

--- a/apps/atlas/src/context/CryptContext.tsx
+++ b/apps/atlas/src/context/CryptContext.tsx
@@ -1,10 +1,16 @@
 import type { Dispatch } from 'react';
 import { createContext, useContext, useReducer } from 'react';
 import { storage } from '@/util/localStorage';
+import { CryptsMax } from '../constants';
+import type { MinMaxRange } from '../types';
 
 const CryptFavoriteLocalStorageKey = 'crypt.favourites';
 
-type StatsFilter = { size: number; numDoors: number; numPoints: number };
+type StatsFilter = {
+  size: MinMaxRange;
+  numDoors: MinMaxRange;
+  numPoints: MinMaxRange;
+};
 
 interface CryptState {
   statsFilter: StatsFilter;
@@ -38,9 +44,9 @@ interface CryptActions {
 
 const defaultFilters = {
   statsFilter: {
-    size: 0,
-    numDoors: 0,
-    numPoints: 0,
+    size: { min: 0, max: CryptsMax.Size },
+    numDoors: { min: 0, max: CryptsMax.NumDoors },
+    numPoints: { min: 0, max: CryptsMax.NumPoints },
   },
   environmentsFilter: [],
   searchIdFilter: '',

--- a/apps/atlas/src/context/GaContext.tsx
+++ b/apps/atlas/src/context/GaContext.tsx
@@ -2,10 +2,12 @@ import type { Dispatch } from 'react';
 import { createContext, useContext, useReducer } from 'react';
 import type { OrderType } from '@/generated/graphql';
 import { storage } from '@/util/localStorage';
+import { LootMax } from '../constants';
+import type { MinMaxRange } from '../types';
 
 const GAFavoriteLocalStorageKey = 'ga.favourites';
 
-type RatingFilter = { bagGreatness: number; bagRating: number };
+type RatingFilter = { bagGreatness: MinMaxRange; bagRating: MinMaxRange };
 
 interface GaState {
   ratingFilter: RatingFilter;
@@ -36,8 +38,8 @@ interface GaActions {
 
 const defaultFilters = {
   ratingFilter: {
-    bagGreatness: 0,
-    bagRating: 0,
+    bagGreatness: { min: 0, max: LootMax.Greatness },
+    bagRating: { min: 0, max: LootMax.Rating },
   },
   selectedOrders: [] as OrderType[],
   searchIdFilter: '',

--- a/apps/atlas/src/context/LootContext.tsx
+++ b/apps/atlas/src/context/LootContext.tsx
@@ -2,10 +2,12 @@ import type { Dispatch } from 'react';
 import { createContext, useContext, useReducer } from 'react';
 import type { OrderType } from '@/generated/graphql';
 import { storage } from '@/util/localStorage';
+import { LootMax } from '../constants';
+import type { MinMaxRange } from '../types';
 
 const LootFavoriteLocalStorageKey = 'loot.favourites';
 
-type RatingFilter = { bagGreatness: number; bagRating: number };
+type RatingFilter = { bagGreatness: MinMaxRange; bagRating: MinMaxRange };
 
 interface LootState {
   ratingFilter: RatingFilter;
@@ -36,8 +38,14 @@ interface LootActions {
 
 const defaultFilters = {
   ratingFilter: {
-    bagGreatness: 0,
-    bagRating: 0,
+    bagGreatness: {
+      min: 0,
+      max: LootMax.Greatness,
+    },
+    bagRating: {
+      min: 0,
+      max: LootMax.Rating,
+    },
   },
   selectedOrders: [] as OrderType[],
   searchIdFilter: '',

--- a/apps/atlas/src/context/RealmContext.tsx
+++ b/apps/atlas/src/context/RealmContext.tsx
@@ -1,18 +1,22 @@
 import type { Dispatch } from 'react';
 import { createContext, useContext, useReducer } from 'react';
+import { RealmsMax } from '@/constants/index';
 import type { OrderType } from '@/generated/graphql';
 import { RealmTraitType } from '@/generated/graphql';
 import { storage } from '@/util/localStorage';
-
+import type { MinMaxRange } from '../types';
 const RealmFavoriteLocalStorageKey = 'realm.favourites';
 
-type RarityFilter = { rarityScore: number; rarityRank: number };
+type RarityFilter = {
+  score: MinMaxRange;
+  rank: MinMaxRange;
+};
 
 type TraitsFilter = {
-  [RealmTraitType.Region]: number;
-  [RealmTraitType.City]: number;
-  [RealmTraitType.Harbor]: number;
-  [RealmTraitType.River]: number;
+  [RealmTraitType.Region]: MinMaxRange;
+  [RealmTraitType.City]: MinMaxRange;
+  [RealmTraitType.Harbor]: MinMaxRange;
+  [RealmTraitType.River]: MinMaxRange;
 };
 
 interface RealmState {
@@ -61,14 +65,20 @@ interface RealmActions {
 
 const defaultFilters = {
   rarityFilter: {
-    rarityScore: 0,
-    rarityRank: 0,
+    score: {
+      min: 0,
+      max: RealmsMax.Score,
+    },
+    rank: {
+      min: 0,
+      max: RealmsMax.Rank,
+    },
   },
   traitsFilter: {
-    [RealmTraitType.Region]: 0,
-    [RealmTraitType.City]: 0,
-    [RealmTraitType.Harbor]: 0,
-    [RealmTraitType.River]: 0,
+    [RealmTraitType.Region]: { min: 0, max: RealmsMax.Region },
+    [RealmTraitType.City]: { min: 0, max: RealmsMax.City },
+    [RealmTraitType.Harbor]: { min: 0, max: RealmsMax.Harbour },
+    [RealmTraitType.River]: { min: 0, max: RealmsMax.River },
   },
   selectedOrders: [] as OrderType[],
   selectedResources: [] as number[],

--- a/apps/atlas/src/types/index.ts
+++ b/apps/atlas/src/types/index.ts
@@ -217,3 +217,8 @@ export interface ResourceCost {
   resourceId: number;
   resourceName: string;
 }
+
+export interface MinMaxRange {
+  min: number;
+  max: number;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6107,6 +6107,174 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/number@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@radix-ui/number@npm:0.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+  checksum: 6c07788b11273c73a4989d4e57d6fd959238b7b12bd8173cf74599866aa0b3d2ac3b852f48c67feb925d02728527975512bcdc7d6b5d5359e4541adfe594d076
+  languageName: node
+  linkType: hard
+
+"@radix-ui/primitive@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@radix-ui/primitive@npm:0.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+  checksum: 09cd886a9f7961b7d94d59bd96c79af69dca38ed99cb1a0a2df4e7ef76d21506d9f4ae3cd85488a2adeb0cac48a1a0f28dd6b621c7027b8e932c90d9d07c3420
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-collection@npm:0.1.4":
+  version: 0.1.4
+  resolution: "@radix-ui/react-collection@npm:0.1.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+    "@radix-ui/react-compose-refs": "npm:0.1.0"
+    "@radix-ui/react-context": "npm:0.1.1"
+    "@radix-ui/react-primitive": "npm:0.1.4"
+    "@radix-ui/react-slot": "npm:0.1.2"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: ddf4ee18e9d63df11824fe04b75e342f731a58a3684d152b0e74b22d36d8450518eb429faff2bcb860517f00e7d82199165dc8f0664ccce5eefaf430c113a20a
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-compose-refs@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@radix-ui/react-compose-refs@npm:0.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: 1a0e9c054b2ca2eb7870f0eeadd155b6bfc8d692c284aa0535afb7e5797c6406df5016273bf3a3f750fc014df5927d7d6178d39d9e362651b6e2dc2d0eddca85
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@radix-ui/react-context@npm:0.1.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: 8295c11ebe98a79939bde672bc38d1960cb1f7d4cb0d2395dea0e87a3cc1980fe3ab6809e7e812da8d27b9752a79645049b7cb9f9e89258c47cb6736ca3f34c5
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:0.1.4":
+  version: 0.1.4
+  resolution: "@radix-ui/react-primitive@npm:0.1.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+    "@radix-ui/react-slot": "npm:0.1.2"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: f3517491df4250c27ce0ea36d12ca68cd6ecc55f596bf79c5fd1afa1f5d1c9f77ae9f30ef03f512dc0a923c77b918b420b0275d3280177f67a712b23c5780508
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slider@npm:0.1.4":
+  version: 0.1.4
+  resolution: "@radix-ui/react-slider@npm:0.1.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+    "@radix-ui/number": "npm:0.1.0"
+    "@radix-ui/primitive": "npm:0.1.0"
+    "@radix-ui/react-collection": "npm:0.1.4"
+    "@radix-ui/react-compose-refs": "npm:0.1.0"
+    "@radix-ui/react-context": "npm:0.1.1"
+    "@radix-ui/react-primitive": "npm:0.1.4"
+    "@radix-ui/react-use-controllable-state": "npm:0.1.0"
+    "@radix-ui/react-use-direction": "npm:0.1.0"
+    "@radix-ui/react-use-layout-effect": "npm:0.1.0"
+    "@radix-ui/react-use-previous": "npm:0.1.1"
+    "@radix-ui/react-use-size": "npm:0.1.1"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: 01917602c3aeb337c1cd7d24c3015af7abe6a39818655e9da69754c35810999dd22233b6a7105b2f4db24ffa6f27301696f9828ceaf170eb72b9e7ff5c7ad337
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@radix-ui/react-slot@npm:0.1.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+    "@radix-ui/react-compose-refs": "npm:0.1.0"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: 6bdf9f79f37e663b34aa204d1d7c7e6e4e1304a7b2a1593bc9c608e0eb8d2252ca31df3d70e5e2a8b3aeb2ec552777fc6bb0b1f9d8609f850384b76fd6242cd4
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-callback-ref@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@radix-ui/react-use-callback-ref@npm:0.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: 25d8ed0679d3c9ac531813c8ba354f3eff8feeef3152b1b62b0d6c6d57aeff1d0a1a7cc509cee1ae3c0608c5de15bd6ed37617bb127b422df5a3f75bf59f733e
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-controllable-state@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@radix-ui/react-use-controllable-state@npm:0.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+    "@radix-ui/react-use-callback-ref": "npm:0.1.0"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: 34e5ac1da90c10eede0343a2bd90e889c30374685010c6444a960c0d642f4aba8326e2bf2bff5d50e624f71ae9c65e4599b39a36a30455b157f17e384086e2ca
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-direction@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@radix-ui/react-use-direction@npm:0.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: a691955b95df4f1d360e235a094c532af5e60862f43fc24eb8eb46d74bf90895158d57bf5e1efbc065d5cf86d17e53b2d5be7530ef4469d1899e4d413f976074
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-layout-effect@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@radix-ui/react-use-layout-effect@npm:0.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: 82064fdd764e56c707243a075a5ec5e7f3c58b2d9e89e66743ad877d73953a415d7af41b897b50553446c0492bb5754d6b19452575653f734f52802f40526ab8
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-previous@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@radix-ui/react-use-previous@npm:0.1.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: 2e4b281fefad852ecc77a28848690dae227c68d06bf4df4e0b58c16a5fe3db2fa5aa41f77590bb0ed2c2725a555679f46c3c3def80edef65892e6ab73f838c73
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-size@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@radix-ui/react-use-size@npm:0.1.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  checksum: 095509c0ddd348b37eed0e770a973ba85897c1230732fe005b332b3d599fcfd68594b5b25d042d461d6a6430022718d184b76826846aa5dcb8cadedb30c15371
+  languageName: node
+  linkType: hard
+
 "@react-spring/animated@npm:~9.4.5":
   version: 9.4.5
   resolution: "@react-spring/animated@npm:9.4.5"
@@ -11104,6 +11272,7 @@ __metadata:
     "@playwright/test": "npm:1.22.2"
     "@popperjs/core": "npm:2.11.5"
     "@quentin-sommer/react-useragent": "npm:3.1.1"
+    "@radix-ui/react-slider": "npm:0.1.4"
     "@react-spring/three": "npm:9.4.5"
     "@react-spring/types": "npm:^9.4.5"
     "@react-spring/web": "npm:^9.4.5"


### PR DESCRIPTION
Resolves #90 

- Refactors slider component to use `@radix-ui/slider` for simple multi-value support
- Min/max values for all filter sliders across Realms, Loot, GA, Crypts
- slider range uses `gte` operator for min, `lte` operator for max, connected to GraphQL