### PR TITLE
Add redirect for coingeccko link 404

### DIFF
--- a/apps/bibliotheca-dao/next.config.js
+++ b/apps/bibliotheca-dao/next.config.js
@@ -189,6 +189,15 @@ const nextConfig = {
     // to bypass https://github.com/zeit/next.js/issues/8251
     PROJECT_ROOT: __dirname,
   },
+  async redirects() {
+    return [
+      {
+        source: '/settling',
+        destination: '/',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 let config = nextConfig;


### PR DESCRIPTION
Also changes the default web3 interface to wagmi/connect-kit 