### PR TITLE
feat: adjust h4 on bibliotheca dao site

### DIFF
--- a/apps/bibliotheca-dao/src/components/PartnerBanner.tsx
+++ b/apps/bibliotheca-dao/src/components/PartnerBanner.tsx
@@ -40,16 +40,19 @@ export const PartnerBanner = () => {
     },
   ];
   return (
-    <div className="relative z-20 flex flex-wrap justify-center w-full h-auto p-10 text-gray-900 shadow-inner sm:p-20 sm:space-x-10 bg-off-300/40 text-off-300">
-      <h4 className="absolute top-0 self-center -mt-4">We work with</h4>{' '}
-      {partners.map((a, index) => {
-        return (
-          <div key={index} className="self-center p-4 ">
-            {' '}
-            <a href={a.url}>{a.icon}</a>{' '}
-          </div>
-        );
-      })}
-    </div>
+    <>
+      <h4 className="text-center -mt-4">We work with</h4>
+      <div className="relative z-20 flex flex-wrap justify-center w-full h-auto p-10 text-gray-900 shadow-inner sm:p-20 sm:space-x-10 bg-off-300/40 text-off-300">
+        {' '}
+        {partners.map((a, index) => {
+          return (
+            <div key={index} className="self-center p-4 ">
+              {' '}
+              <a href={a.url}>{a.icon}</a>{' '}
+            </div>
+          );
+        })}
+      </div>
+    </>
   );
 };


### PR DESCRIPTION
I've been aware of this overlap for a little while now on the dao's website:

![Screen Shot 2023-03-05 at 9 17 46 PM](https://user-images.githubusercontent.com/95005566/223008053-e2375310-4139-4ed0-857b-801492161e89.png)

so I figured I would fix it:

![Screen Shot 2023-03-05 at 9 48 46 PM](https://user-images.githubusercontent.com/95005566/223008152-862869fd-bba7-453e-b601-31b556623454.png)
